### PR TITLE
Disable `bioformats.zeissczi.allow.autostitch`

### DIFF
--- a/extra/Fiji.app/plugins/Scripts/Plugins/AutoRun/Set_IMCF_Prefs.js
+++ b/extra/Fiji.app/plugins/Scripts/Plugins/AutoRun/Set_IMCF_Prefs.js
@@ -67,6 +67,8 @@ function checkFileAndSetPrefs() {
     } else {
         log_debug("'imcf' key not found in imcf-settings.json.");
     }
+
+    Prefs.set("bioformats.zeissczi.allow.autostitch", false);
 }
 
 // Utility function to read file content


### PR DESCRIPTION
Add the option to set the autostitch to False for CZI files.