### PR TITLE
Add stable Fiji to the list of built versions

### DIFF
--- a/.github/workflows/imcf-fiji-assembly.yml
+++ b/.github/workflows/imcf-fiji-assembly.yml
@@ -2,7 +2,7 @@ name: IMCF Fiji Assembly 🏗️
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       reason:
@@ -14,7 +14,8 @@ jobs:
   assemble-fiji:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ ubuntu-latest, windows-latest ]
+        channel: [ fiji-latest, fiji-stable ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 📥 Checkout repository
@@ -45,8 +46,9 @@ jobs:
         id: cache-fiji
         uses: actions/cache@v4
         with:
-          path: fiji-latest-*.zip
-          key: fiji-base-${{ steps.set_platform.outputs.PLATFORM }}-${{ hashFiles('manage/assemble-fresh-fiji-installation.sh') }}
+          path: fiji-*.zip
+          key: fiji-base-${{ matrix.channel }}-${{ steps.set_platform.outputs.PLATFORM
+            }}-${{ hashFiles('manage/assemble-fresh-fiji-installation.sh') }}
 
       - name: 🛠️ Install X11 libraries (Linux only)
         if: matrix.os == 'ubuntu-latest'
@@ -58,12 +60,13 @@ jobs:
       - name: 🏃‍♂️ Run the assembly script
         shell: bash
         run: |
-          bash manage/assemble-fresh-fiji-installation.sh manage/update-sites-all.json $PLATFORM
+          bash manage/assemble-fresh-fiji-installation.sh manage/update-sites-all.json $PLATFORM ${{ matrix.channel }}
 
       - name: 📤 Upload Fiji artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Fiji.app-${{ steps.set_platform.outputs.PLATFORM_NAME }}
+          name: Fiji.app-${{ matrix.channel }}-${{
+            steps.set_platform.outputs.PLATFORM_NAME }}
           path: ${{ steps.set_platform.outputs.FIJI_DIR }}
 
   release:
@@ -75,27 +78,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 📥 Download Linux artifact
+      - name: 📥 Download Fiji artifacts (both channels)
         uses: actions/download-artifact@v4
         with:
-          name: Fiji.app-linux
-          path: ./artifacts/Fiji.app-linux
+          name: Fiji.app-fiji-latest-linux
+          path: ./artifacts/Fiji.app-fiji-latest-linux
 
-      - name: 📥 Download Windows artifact
+      - name: 📥 Download Fiji artifacts (fiji-stable linux)
         uses: actions/download-artifact@v4
         with:
-          name: Fiji.app-windows
-          path: ./artifacts/Fiji.app-windows
+          name: Fiji.app-fiji-stable-linux
+          path: ./artifacts/Fiji.app-fiji-stable-linux
+
+      - name: 📥 Download Fiji artifacts (fiji-latest windows)
+        uses: actions/download-artifact@v4
+        with:
+          name: Fiji.app-fiji-latest-windows
+          path: ./artifacts/Fiji.app-fiji-latest-windows
+
+      - name: 📥 Download Fiji artifacts (fiji-stable windows)
+        uses: actions/download-artifact@v4
+        with:
+          name: Fiji.app-fiji-stable-windows
+          path: ./artifacts/Fiji.app-fiji-stable-windows
 
       - name: 🔧 Ensure downloaded Fiji launchers are executable
         run: |
           echo "Setting executable bits for Fiji artifacts"
-          chmod -R +x ./artifacts/Fiji.app-linux || true
-          chmod -R +x ./artifacts/Fiji.app-windows || true
-          # Ensure jaunch helper and primary launchers are executable
-          chmod +x ./artifacts/Fiji.app-linux/fiji-linux-x64 || true
-          chmod +x ./artifacts/Fiji.app-linux/fiji || true
-          chmod +x ./artifacts/Fiji.app-linux/config/jaunch/jaunch-linux-x64 || true
+          chmod -R +x ./artifacts/Fiji.app-* || true
+          # Ensure jaunch helper and primary launchers are executable where present
+          chmod -R +x ./artifacts/*/fiji-linux-x64 || true
+          chmod -R +x ./artifacts/*/fiji || true
+          chmod -R +x ./artifacts/*/config/jaunch/jaunch-linux-x64 || true
 
       - name: 📦 Create zip files and set release tag
         id: prepare_release
@@ -108,8 +122,11 @@ jobs:
           echo "RELEASE_TAG=v${TIMESTAMP}" >> $GITHUB_OUTPUT
           echo "RELEASE_NAME=Fiji-IMCF ${CURRENT_DATE} ${CURRENT_TIME}" >> $GITHUB_OUTPUT
           cd artifacts
-          zip -r "Fiji.app-linux-${TIMESTAMP}.zip" Fiji.app-linux
-          zip -r "Fiji.app-windows-${TIMESTAMP}.zip" Fiji.app-windows
+          for d in Fiji.app-*; do
+            if [ -d "$d" ]; then
+              zip -r "${d}-${TIMESTAMP}.zip" "$d"
+            fi
+          done
           cd ..
 
       - name: 🔎 List downloaded artifacts
@@ -126,5 +143,4 @@ jobs:
           draft: false
           prerelease: true
           files: |
-            ./artifacts/Fiji.app-linux-*.zip
-            ./artifacts/Fiji.app-windows-*.zip
+            ./artifacts/*.zip

--- a/manage/assemble-fresh-fiji-installation.sh
+++ b/manage/assemble-fresh-fiji-installation.sh
@@ -11,7 +11,7 @@ echo "$(ls)"
 exit_usage() {
     echo "Usage:"
     echo
-    echo "$0 ./list-of-update-sites.json platform"
+    echo "$0 ./list-of-update-sites.json platform [fiji-channel]"
     echo
     exit 1
 }
@@ -28,6 +28,7 @@ fi
 
 UPD_SITES=$1
 PLATFORM="$2"
+CHANNEL="${3:-fiji-latest}"
 
 FIJI_DIR="Fiji.app"
 if [ -d "$FIJI_DIR" ]; then
@@ -47,8 +48,15 @@ else
 fi
 
 echo ">>> Working for platform: $PLATFORM"
-DL_BASE="https://downloads.imagej.net/fiji/latest"
-PKG="fiji-latest-${PLATFORM_NUMBERED}-jdk.zip"
+if [[ "$CHANNEL" == *stable* ]]; then
+    DL_BASE="https://downloads.imagej.net/fiji/stable"
+elif [[ "$CHANNEL" == *latest* ]]; then
+    DL_BASE="https://downloads.imagej.net/fiji/latest"
+else
+    # default to latest if unknown
+    DL_BASE="https://downloads.imagej.net/fiji/latest"
+fi
+PKG="${CHANNEL}-${PLATFORM_NUMBERED}-jdk.zip"
 FIJI_DIR="Fiji.app-${PLATFORM}"
 
 DL_URI="$DL_BASE/$PKG"

--- a/manage/assemble-fresh-fiji-installation.sh
+++ b/manage/assemble-fresh-fiji-installation.sh
@@ -86,7 +86,19 @@ echo -n "Extracting the package: "
 # produces warnings like "cannot set UID ... Operation not permitted".
 # test
 unzip -q -DD "$PKG"
-mv "Fiji" "$FIJI_DIR"
+# Find the extracted Fiji directory (could be 'Fiji' or 'Fiji.app')
+extracted_dir=""
+for d in Fiji*; do
+    if [ -d "$d" ]; then
+        extracted_dir="$d"
+        break
+    fi
+done
+if [ -z "$extracted_dir" ]; then
+    echo "ERROR: no extracted Fiji directory found after unpacking $PKG"
+    exit 2
+fi
+mv -- "$extracted_dir" "$FIJI_DIR"
 echo -e "[DONE]\n"
 
 # Ensure launcher and jaunch helper are executable (some zip extractions


### PR DESCRIPTION
This pull request updates the Fiji assembly workflow and its supporting script to add support for both the "fiji-latest" and "fiji-stable" channels, improving flexibility for building and releasing different Fiji versions. The changes affect both the GitHub Actions workflow and the assembly script to handle multiple channels, update artifact naming conventions, and streamline artifact handling.

**Key changes:**

### Multi-channel support and workflow improvements

* Added a `channel` matrix (with values `fiji-latest` and `fiji-stable`) to the GitHub Actions workflow in `.github/workflows/imcf-fiji-assembly.yml`, so builds are now performed for both channels on each OS. The assembly script is updated to accept an optional channel argument and defaults to `fiji-latest` if not specified. (`[[1]](diffhunk://#diff-ab500e92544ae9a2b962680878fc02a1685c83f5444a3206920ca82763ad28a1R18)`, `[[2]](diffhunk://#diff-fe2159d1b191b0790f20d0f40d1db2cf069c7c1ece23ef17bede7adafed60623L14-R14)`, `[[3]](diffhunk://#diff-fe2159d1b191b0790f20d0f40d1db2cf069c7c1ece23ef17bede7adafed60623R31)`)
* The workflow now downloads, handles, and uploads artifacts for both channels and both platforms, with updated naming conventions (e.g., `Fiji.app-fiji-latest-linux`). Artifact handling and permissions are generalized to support the new structure. (`[[1]](diffhunk://#diff-ab500e92544ae9a2b962680878fc02a1685c83f5444a3206920ca82763ad28a1L48-R51)`, `[[2]](diffhunk://#diff-ab500e92544ae9a2b962680878fc02a1685c83f5444a3206920ca82763ad28a1L61-R69)`, `[[3]](diffhunk://#diff-ab500e92544ae9a2b962680878fc02a1685c83f5444a3206920ca82763ad28a1L78-R112)`)

### Artifact packaging and release

* The artifact zipping and release steps are updated to dynamically package all channel/platform combinations and upload them in a single release, rather than hardcoding for just "linux" and "windows". (`[[1]](diffhunk://#diff-ab500e92544ae9a2b962680878fc02a1685c83f5444a3206920ca82763ad28a1L111-R129)`, `[[2]](diffhunk://#diff-ab500e92544ae9a2b962680878fc02a1685c83f5444a3206920ca82763ad28a1L129-R146)`)

### Assembly script enhancements

* The `manage/assemble-fresh-fiji-installation.sh` script now determines the correct download base URL and package name based on the specified channel, and is more robust in locating the extracted Fiji directory after unzipping (handles both `Fiji` and `Fiji.app`). (`[[1]](diffhunk://#diff-fe2159d1b191b0790f20d0f40d1db2cf069c7c1ece23ef17bede7adafed60623R51-R59)`, `[[2]](diffhunk://#diff-fe2159d1b191b0790f20d0f40d1db2cf069c7c1ece23ef17bede7adafed60623L81-R101)`)

These changes make the build and release process more flexible and future-proof, supporting both stable and latest Fiji releases with improved artifact management.